### PR TITLE
Add missing functions to $mdThemingProvider externs

### DIFF
--- a/contrib/externs/angular-material.js
+++ b/contrib/externs/angular-material.js
@@ -579,6 +579,15 @@ md.$mdThemingProvider.prototype.theme = function(name, opt_parentTheme) {};
 /** @param {string} nonce */
 md.$mdThemingProvider.prototype.setNonce = function(nonce) {};
 
+/** @param {string} styles */
+md.$mdThemingProvider.prototype.registerStyles = function(styles) {};
+
+/** 
+ * @param {?Object=} options 
+ * @return {!Function}
+ */
+md.$mdThemingProvider.prototype.enableBrowserColor = function(options) {};
+
 /******************************************************************************
  * $mdTheming service
  *****************************************************************************/


### PR DESCRIPTION
Adding missing registerStyles() and enableBrowserColor() externs to Angular Material's $mdThemingProvider service.